### PR TITLE
add macro for parameter objects

### DIFF
--- a/lib/blue_bird/controller.ex
+++ b/lib/blue_bird/controller.ex
@@ -138,10 +138,6 @@ defmodule BlueBird.Controller do
   end
 
   defmacro api_parameters(id, do: block) do
-    process_parameters(id, block)
-  end
-
-  defp process_parameters(id, block) do
     metadata      = extract_metadata(block)
     parameters    = extract_parameters(metadata)
 

--- a/test/generator_test.exs
+++ b/test/generator_test.exs
@@ -214,7 +214,12 @@ defmodule BlueBird.Test.GeneratorTest do
       method: "POST",
       note: nil,
       warning: nil,
-      parameters: [%Parameter{description: "ID", name: "id", type: "int"}],
+      parameters: [
+        %Parameter{description: "ID", name: "id", type: "int"},
+        %Parameter{members: [], name: "page", type: "number"},
+        %Parameter{default: 100, name: "limit", type: "number"},
+        %Parameter{name: "order_by", type: "string"}
+      ],
       path: "/statler/:id",
       requests: [],
       title: "Post Statler"

--- a/test/support/controller.ex
+++ b/test/support/controller.ex
@@ -22,9 +22,16 @@ defmodule BlueBird.Test.Support.TestController do
     warning "Warning"
   end
 
+  api_parameters :my_parameters do
+    parameter :page, :number
+    parameter :limit, :number, [default: 100]
+    parameter :order_by, :string
+  end
+
   api :POST, "/statler/:id" do
     title "Post Statler"
     parameter :id, :int, [description: "ID"]
+    parameter_object :my_parameters
   end
 
   def catchall(conn, params) do


### PR DESCRIPTION
This is a little experiment about shared parameter objects. Often times, multiple parameters are shared between several routes, and it would be nice if we could define them only once and then reference them within the `api/3` macro. 

This PR adds the `api_parameters/2` macro. The first parameter is an arbitrary unique ID to use as a reference, the second parameter is a do block in which you can define the parameters just like in the `api/3` macro.

```
api_parameters :my_parameters do
    parameter :page, :number
    parameter :limit, :number, [default: 100]
    parameter :order_by, :string
end
```

You can then reference this set of parameters with the `parameter_object` key within the `api/3` macro.

```
api :POST, "/statler/:id" do
    title "Post Statler"
    parameter :id, :int, [description: "ID"]
    parameter_object :my_parameters
end
```

I'm not sure about the exact api and naming yet. But this PR demonstrates how we can combine macros to allow reusing api doc settings. This might be useful for swagger schema objects and blueprint attributes as well.