### PR TITLE
Introduce request title

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ test "list comments for post", %{conn: conn} do
   insert_posts_with_comments()
 
   conn = conn
-  |> get(comments_path(conn, :index)
-  |> BlueBird.ConnLogger.save()
+  |> get(comments_path(conn, :index))
+  |> BlueBird.ConnLogger.save(title: "Without params")
 
   assert json_response(conn, 200)
 end

--- a/lib/blue_bird/conn_logger.ex
+++ b/lib/blue_bird/conn_logger.ex
@@ -75,8 +75,10 @@ defmodule BlueBird.ConnLogger do
       iex> save(conn)
       :ok
   """
-  @spec save(Plug.Conn.t()) :: :ok
-  def save(conn) do
+  @type save_option :: {:title, String.t()}
+  @spec save(Plug.Conn.t(), [save_option()]) :: Plug.Conn.t()
+  def save(conn, opts \\ []) do
+    conn = Plug.Conn.assign(conn, :blue_bird_opts, opts)
     GenServer.cast(__MODULE__, {:save, conn})
     conn
   end

--- a/lib/blue_bird/generator.ex
+++ b/lib/blue_bird/generator.ex
@@ -212,9 +212,12 @@ defmodule BlueBird.Generator do
 
   @spec request_map(%PhxRoute{}, %Plug.Conn{}) :: Request.t()
   defp request_map(route, conn) do
+    opts = conn.assigns[:blue_bird_opts]
+
     %Request{
       method: conn.method,
       path: route.path,
+      title: Keyword.get(opts, :title),
       headers: filter_headers(conn.req_headers, :request),
       path_params: conn.path_params,
       body_params: conn.body_params,

--- a/lib/blue_bird/request.ex
+++ b/lib/blue_bird/request.ex
@@ -6,6 +6,7 @@ defmodule BlueBird.Request do
     :method,
     :path,
     :response,
+    :title,
     path_params: %{},
     body_params: %{},
     headers: [],
@@ -18,10 +19,11 @@ defmodule BlueBird.Request do
   @type t :: %BlueBird.Request{
           method: String.t(),
           path: String.t(),
-          headers: [{String.t(), String.t()}],
+          response: BlueBird.Response.t(),
+          title: String.t(),
           path_params: %{optional(String.t()) => String.t()},
           body_params: %{optional(String.t()) => String.t()},
-          query_params: %{optional(String.t()) => String.t()},
-          response: BlueBird.Response.t()
+          headers: [{String.t(), String.t()}],
+          query_params: %{optional(String.t()) => String.t()}
         }
 end

--- a/lib/blue_bird/writer/blueprint.ex
+++ b/lib/blue_bird/writer/blueprint.ex
@@ -132,6 +132,7 @@ defmodule BlueBird.Writer.Blueprint do
   end
 
   defp process_request(request) do
+    title = request.title || request.response.status
     content_type = get_content_type(request.headers)
 
     req_str =
@@ -146,7 +147,7 @@ defmodule BlueBird.Writer.Blueprint do
     if req_str == "" && content_type == "" do
       ""
     else
-      "+ Request #{request.response.status}#{content_type}\n\n" <>
+      "+ Request #{title}#{content_type}\n\n" <>
         req_str <> "\n"
     end
   end

--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -3,6 +3,7 @@ defmodule BlueBird.Test.FormatterTest do
 
   alias BlueBird.Formatter
 
+  @tag :capture_log
   test "Formatter runs Generator and Writer" do
     path_apib = Path.join(["priv", "static", "docs", "api.apib"])
     # path_swagger = Path.join(["priv", "static", "docs", "swagger.json"])

--- a/test/generator_test.exs
+++ b/test/generator_test.exs
@@ -267,6 +267,19 @@ defmodule BlueBird.Test.GeneratorTest do
       assert length(post_route.requests) == 1
     end
 
+    test "includes request title" do
+      :get
+      |> build_conn("/waldorf")
+      |> Router.call(@opts)
+      |> ConnLogger.save(title: "Waldorf")
+
+      Logger.disable(self())
+      route = Generator.run() |> find_route("GET", "/waldorf")
+      request = hd(route.requests)
+
+      assert request.title == "Waldorf"
+    end
+
     test "includes response status, headers and body" do
       :get
       |> build_conn("/waldorf")

--- a/test/writer/blueprint_test.exs
+++ b/test/writer/blueprint_test.exs
@@ -228,6 +228,7 @@ defmodule BlueBird.Test.Writer.BlueprintTest do
             %Request{
               method: POST,
               path: "/users/:id/pets",
+              title: "Add pet",
               headers: [{"accept", "application/json"}],
               path_params: %{},
               body_params: %{},
@@ -265,7 +266,7 @@ defmodule BlueBird.Test.Writer.BlueprintTest do
 
                          {"name":"George","kind":"dog"}
 
-             + Request 200
+             + Request Add pet
 
                  + Headers
 


### PR DESCRIPTION
Adds option to name test requests and show that request title in final documentation.
Usage: `|> BlueBird.ConnLogger.save(title: "Without params")` (also added to readme).
Defaults to response status given no title supplied.
Inspired by https://github.com/api-hogs/bureaucrat test helpers.
